### PR TITLE
Added support for Tomcat 8.5

### DIFF
--- a/conf/tomcat-users.xml
+++ b/conf/tomcat-users.xml
@@ -1,7 +1,11 @@
-<?xml version='1.0' encoding='utf-8'?>
-<tomcat-users>
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
 <role rolename="manager-gui"/>
 <role rolename="manager-script"/>
-<user username="admin" password="admin" roles="manager-gui" />
-<user username="adminscript" password="passwordscript" roles="manager-script" />
+<user username="admin" password="admin" roles="manager-gui"/>
+<user username="adminscript" password="passwordscript" roles="manager-script"/>
 </tomcat-users>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,10 +4,10 @@ echo "] Packaging the app ..."
 mvn package
 echo "] Packaging complete."
 echo ""
-echo "] Restarting tomcat7 ..."
-sudo service tomcat7 restart
+echo "] Restarting tomcat ..."
+sudo service tomcat restart
 echo "] Restart complete."
 echo ""
 echo "] Deploying Application ..."
-mvn tomcat7:deploy
+mvn tomcat:deploy
 echo "] Deploy complete"

--- a/scripts/front-end.sh
+++ b/scripts/front-end.sh
@@ -1,1 +1,1 @@
-sudo cp -rf src/main/webapp/WEB-INF/view /var/lib/tomcat7/webapps/protocolanalyzer/WEB-INF
+sudo cp -rf src/main/webapp/WEB-INF/view /opt/tomcat/webapps/protocolanalyzer/WEB-INF

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -6,10 +6,10 @@ echo "] Removing the war file ..."
 sudo rm -rf /var/lib/tomcat7/webapps/protocolanalyzer.war /var/lib/tomcat7/webapps/protocolanalyzer
 echo "] Remove complete."
 echo ""
-echo "] Restarting tomcat7 ..."
-sudo service tomcat7 restart
+echo "] Restarting tomcat ..."
+sudo service tomcat restart
 echo "] Restart complete."
 echo ""
 echo "] Deploying Application ..."
-mvn tomcat7:deploy
+mvn tomcat:deploy
 echo "] Deploy complete"

--- a/tomcat.service
+++ b/tomcat.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Apache Tomcat Web Application Container
+After=network.target
+
+[Service]
+Type=forking
+
+Environment=JAVA_HOME=/usr/lib/jvm/java-8-oracle
+Environment=CATALINA_PID=/opt/tomcat/temp/tomcat.pid
+Environment=CATALINA_HOME=/opt/tomcat
+Environment=CATALINA_BASE=/opt/tomcat
+Environment='CATALINA_OPTS=-Xms512M -Xmx1024M -server -XX:+UseParallelGC'
+Environment='JAVA_OPTS=-Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom'
+
+ExecStart=/opt/tomcat/bin/startup.sh
+ExecStop=/opt/tomcat/bin/shutdown.sh
+
+User=tomcat
+Group=tomcat
+UMask=0007
+RestartSec=10
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
@prasadtalasila 
The changes are done to support Tomcat 8.5. There are errors which I am still working on. 
1. Deploy command is not working as expected. It is throwing the following 

> [ERROR] Failed to execute goal org.codehaus.mojo:tomcat-maven-plugin:1.1:deploy (default-cli) on project protocolanalyzer: Cannot invoke Tomcat manager: Error writing to server -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

2. I had to add a new file tomcat.service to add tomcat as a service. 

 